### PR TITLE
Fix/ Checkbox/radio labels displaying on separate lines 

### DIFF
--- a/src/3-general/form/_form.scss
+++ b/src/3-general/form/_form.scss
@@ -1,3 +1,12 @@
 .field {
   margin-bottom: $form-spacing*3;
 }
+
+.field--inline-label {
+  display: flex;
+  align-items: center;
+
+  label {
+    flex-grow: 1;
+  }
+}

--- a/src/3-general/form/_radio_checkbox.scss
+++ b/src/3-general/form/_radio_checkbox.scss
@@ -4,21 +4,21 @@
 //
 // Markup:
 // <div class="fields">
-//    <div class="field">
-//      <label for="radio">radio</label>
+//    <div class="field field--inline-label">
 //      <input type="radio" id="radio">
+//      <label for="radio">radio</label>
 //    </div>
-//    <div class="field">
-//      <label for="checkbox">checkbox</label>
+//    <div class="field field--inline-label">
 //      <input type="checkbox" id="checkbox">
+//      <label for="checkbox">checkbox</label>
 //    </div>
-//    <div class="field">
-//      <label for="radio-disabled">radio disabled</label>
+//    <div class="field field--inline-label">
 //      <input type="radio" id="radio-disabled" disabled>
+//      <label for="radio-disabled">radio disabled</label>
 //    </div>
-//    <div class="field">
-//      <label for="checkbox-disabled">checkbox disabled</label>
+//    <div class="field field--inline-label">
 //      <input type="checkbox" id="checkbox-disabled" disabled>
+//      <label for="checkbox-disabled">checkbox disabled</label>
 //    </div>
 //  </div>
 //
@@ -30,5 +30,5 @@ input[type="radio"],
 input[type="checkbox"] {
   width: $check-radio-size;
   height: $check-radio-size;
-  margin-top: 0.6em;
+  margin-right: 0.6em;
 }

--- a/src/5-navigation/search/_index.scss
+++ b/src/5-navigation/search/_index.scss
@@ -8,13 +8,13 @@
 //     Search for:
 //   </label>
 //   <div class="context-switch">
-//     <div class="field">
+//     <div class="field field--inline-label">
 //       <input name="context" type="radio" id="search-website-content" value="website-content">
 //       <label for="search-website-content">
 //         Website content
 //       </label>
 //     </div>
-//     <div class="field">
+//     <div class="field field--inline-label">
 //       <input name="context" type="radio" id="search-datasets" value="datasets">
 //       <label for="search-datasets">
 //         Datasets
@@ -44,8 +44,8 @@
     justify-content: space-between;
   }
   label,
-  input {
-    margin-right: 15px;
+  input[type="text"] {
+    margin-right: 20px;
   }
   @include breakpoint(md) {
     flex-direction: row;

--- a/src/7-layout/header/_index.scss
+++ b/src/7-layout/header/_index.scss
@@ -80,14 +80,14 @@
 //             Search for:
 //           </label>
 //           <div class="context-switch">
-//             <div class="field">
+//             <div class="field field--inline-label">
 //               <input id="search-for-website-content" type="radio" class="search-form-context" name="header-search-context"
 //                 value="content" checked="checked">
 //               <label for="search-for-website-content">
 //                 Website content
 //               </label>
 //             </div>
-//             <div class="field">
+//             <div class="field field--inline-label">
 //               <input id="search-for-datasets" type="radio" class="search-form-context" name="header-search-context"
 //                 value="datasets">
 //               <label for="search-for-datasets">


### PR DESCRIPTION
Hey @gorriecoe, is this going to work as a fix for https://github.com/data-govt-nz/rua/issues/22? Basically just adds a modifier to the `.field` class to allow for labels to appear inline with radio/checkbox inputs. Let me know if you had other ideas of how you wanted to tackle this.