### PR TITLE
Add an optional namespace to data attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ gulp
 ```
 
 ```js
+// Optionally set window.dataTargetNamespace to a custom value (e.g. 'rua-' would mean you'd use `data-rua-toggle="..."`)
+
 import {
     toggler,
     matchHeight,

--- a/src/9-plugins/match-height/apply.js
+++ b/src/9-plugins/match-height/apply.js
@@ -4,6 +4,7 @@ import parseOptions from './parseOptions'
 import rowsCalc from './rowsCalc'
 
 export default function (elements, options) {
+  const namespace = typeof window.dataTargetNamespace === 'undefined' ? '' : window.dataTargetNamespace.toString()
   var opts = parseOptions(options),
     $elements = $(elements),
     rows = [$elements]
@@ -18,7 +19,7 @@ export default function (elements, options) {
   // cache the original inline style
   $hiddenParents.each(function () {
     var $that = $(this)
-    $that.data('style-cache', $that.attr('style'))
+    $that.data(namespace + 'style-cache', $that.attr('style'))
   })
 
   // temporarily must force hidden parents visible
@@ -38,7 +39,7 @@ export default function (elements, options) {
       }
 
       // cache the original inline style
-      $that.data('style-cache', $that.attr('style'))
+      $that.data(namespace + 'style-cache', $that.attr('style'))
 
       $that.css({
         'display': display,
@@ -59,7 +60,7 @@ export default function (elements, options) {
     // revert original inline styles
     $elements.each(function () {
       var $that = $(this);
-      $that.attr('style', $that.data('style-cache') || '')
+      $that.attr('style', $that.data(namespace + 'style-cache') || '')
     })
   }
 
@@ -133,7 +134,7 @@ export default function (elements, options) {
   // revert hidden parents
   $hiddenParents.each(function () {
     var $that = $(this)
-    $that.attr('style', $that.data('style-cache') || null)
+    $that.attr('style', $that.data(namespace + 'style-cache') || null)
   })
 
   // restore scroll position if enabled

--- a/src/9-plugins/match-height/index.js
+++ b/src/9-plugins/match-height/index.js
@@ -99,15 +99,16 @@ function bindUpdate(throttle, event) {
 
 export default function () {
   const groups = {}
+  const namespace = typeof window.dataTargetNamespace === 'undefined' ? '' : window.dataTargetNamespace.toString()
 
   /*
    *  bind events
    */
 
   // generate groups by their groupId set by elements using data-match-height
-  $('[data-mh]').each(function () {
+  $('[data-' + namespace + 'mh]').each(function () {
     const element = $(this),
-      groupId = element.data('mh')
+      groupId = element.data(namespace + 'mh')
 
     if (groupId in groups) {
       groups[groupId] = groups[groupId].add(element)

--- a/src/9-plugins/toggler/index.js
+++ b/src/9-plugins/toggler/index.js
@@ -73,13 +73,14 @@ const attributes = [
 ].concat(events)
 
 export default function () {
+  const namespace = typeof window.dataTargetNamespace === 'undefined' ? '' : window.dataTargetNamespace.toString()
 
   attributes.forEach(function ({
     name,
     forceState
   }) {
-    $('[data-' + name + ']').each(function() {
-      const data = parseData(this, name, {
+    $('[data-' + namespace + name + ']').each(function() {
+      const data = parseData(this, namespace + name, {
         forceState
       })
 
@@ -94,9 +95,9 @@ export default function () {
     type,
     forceState
   }) {
-    $(document).on(type, '[data-' + name + ']', function (event) {
+    $(document).on(type, '[data-' + namespace + name + ']', function (event) {
       event.preventDefault()
-      const data = parseData(this, name, {
+      const data = parseData(this, namespace + name, {
         forceState
       })
       data.functions.forEach(function(parameter) {

--- a/src/9-plugins/toggler/options/trigger.js
+++ b/src/9-plugins/toggler/options/trigger.js
@@ -33,13 +33,15 @@ export function run({
   state,
   variables
 }) {
+  const namespace = typeof window.dataTargetNamespace === 'undefined' ? '' : window.dataTargetNamespace.toString()
+
   variables.forEach(function (selector) {
     const o = selector.split('=>')
     const elements = $(o[0])
     state = (o[1]) ? (o[1] == 'true') : state
 
     elements.each(function (index, element) {
-      const data = parseData(element, 'toggle', {
+      const data = parseData(element, namespace + 'toggle', {
         forceState: state
       })
       data.functions.forEach(function(parameter) {

--- a/src/9-plugins/toggler/parseData.js
+++ b/src/9-plugins/toggler/parseData.js
@@ -2,9 +2,6 @@
 
 import split from './split'
 
-const optionDelimiter = ';',
-  funcDelimiter = ':',
-  tsAttr = 'toggle-state'
 
 export default function (
   element,
@@ -17,6 +14,10 @@ export default function (
     functions: [],
     state: true
   }
+  const namespace = typeof window.dataTargetNamespace === 'undefined' ? '' : window.dataTargetNamespace.toString()
+  const optionDelimiter = ';',
+    funcDelimiter = ':',
+    tsAttr = namespace + 'toggle-state'
 
   if (typeof forceState !== typeof undefined) {
     data.state = forceState
@@ -44,7 +45,7 @@ export default function (
     })
   } else {
     console.log(
-      'No options defined',
+      'No options defined for data-' + dataAttribute,
       element
     )
   }

--- a/src/9-plugins/tooltip/index.js
+++ b/src/9-plugins/tooltip/index.js
@@ -18,15 +18,16 @@
 
 import tooltip from 'tooltip.js'
 
-const placementAttr = 'tooltip-placement',
-  triggerAttr = 'tooltip-trigger',
-  defaultplacement = 'top', // End refers to right or bottom
-  defaultTrigger = 'hover focus'
-
 export default function () {
-  $('[data-tooltip]').each(function(index, element){
+  const namespace = typeof window.dataTargetNamespace === 'undefined' ? '' : window.dataTargetNamespace.toString()
+  const placementAttr = namespace + 'tooltip-placement',
+    triggerAttr = namespace + 'tooltip-trigger',
+    defaultplacement = 'top', // End refers to right or bottom
+    defaultTrigger = 'hover focus'
+
+  $('[data-' + namespace + 'tooltip]').each(function(index, element){
     const $element = $(element),
-      title = $element.data('tooltip'),
+      title = $element.data(namespace + 'tooltip'),
       placement = ($element.data(placementAttr)) ? $element.data(placementAttr) : defaultplacement,
       trigger = ($element.data(triggerAttr)) ? $element.data(triggerAttr) : defaultTrigger
 


### PR DESCRIPTION
CKAN already uses `data-toggle` and some others which interferes with the rua js (breaks).
Have added an optional namespace e.g. `data-rua-toggle="..."`

This way we can include the pre-built rua.js but before it's run/included we set `window.ruaNamespace`
