### PR TITLE
Update breakpoint to show header on larger screens

### DIFF
--- a/src/1-helpers/_breakpoints.scss
+++ b/src/1-helpers/_breakpoints.scss
@@ -3,7 +3,7 @@ $breakpoints: (
   default: 0,
   xs: 480px,
   sm: 768px,
-  md: 992px,
+  md: 952px,
   lg: 1200px
 ) !default;
 

--- a/src/7-layout/header/_index.scss
+++ b/src/7-layout/header/_index.scss
@@ -204,7 +204,12 @@ $menu-item-padding-left: get-side($site-header-menu-item-padding, 'left');
 
     &__nav-container {
       position: relative;
-      z-index: 2;;
+      z-index: 2;
+      @include breakpoint(md down) {
+        width: 100%;
+        padding-left: 34px;
+        padding-right: 18px;
+      }
     }
 
     &__inner {
@@ -219,11 +224,11 @@ $menu-item-padding-left: get-side($site-header-menu-item-padding, 'left');
 
     &__navigation {
         display: none;
-        @include breakpoint(lg) {
+        @include breakpoint(md) {
             flex-grow: 1;
             display: flex;
             flex-direction: row-reverse;
-            padding: rem(0 10);
+            padding-right: rem(5);
         }
     }
 
@@ -275,7 +280,7 @@ $menu-item-padding-left: get-side($site-header-menu-item-padding, 'left');
 .navigation-toggle {
     color: color('primary');
     order: -1;
-    @include breakpoint(lg) {
+    @include breakpoint(md) {
         display: none;
     }
 }


### PR DESCRIPTION
Was hiding the header nav too quickly. No idea if this is how I should go about this, but seems to work for me for both data and catalogue.