### PR TITLE
Change back-to-top class

### DIFF
--- a/src/7-layout/back-to-top/_index.scss
+++ b/src/7-layout/back-to-top/_index.scss
@@ -3,14 +3,14 @@
 // @todo
 //
 // Markup:
-// <a class="site-back-to-top" href="#top">
+// <a class="site-go-back-to-top" href="#top">
 //   <span class="ri ri-arrow-up"></span>
 //   Top
 // </a>
 //
 // Styleguide: Layout.BackToTop
 
-.site-back-to-top {
+.site-go-back-to-top {
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -43,7 +43,7 @@
 @include breakpoint(sm down) {
   // Remove back to top while keyboard is active on mobile.
   body:focus-within {
-    .site-back-to-top {
+    .site-go-back-to-top {
       display: none;
     }
   }


### PR DESCRIPTION
This is a bit a of a 'magical fix' to resolve an issue where the back-to-top button is not clickable in Chrome on Android OS. 

We (GIS) think this is due to Google Tag Manager (GTM) third party JS hi-jacking the click event on data.govt.nz but we haven't been able to find the cause in GTM.

But changing the class name resolves the issue so...