### PR TITLE
Hide from Android Mobile devices (where possible)

### DIFF
--- a/src/7-layout/back-to-top/_index.scss
+++ b/src/7-layout/back-to-top/_index.scss
@@ -48,3 +48,69 @@
     }
   }
 }
+
+// Hide from Android Mobile devices (where possible)
+// - Due to an gnarly issue where the back-to-top button is not clickable in Chrome on Android OS
+
+// Portrait orientation up to current largest common mobile device-width
+@media screen and (max-device-width: 480px) and (orientation: portrait){
+    .site-go-back-to-top {
+        display: none;
+    }
+}
+
+// Landscape orientation up to one pixel below smallest common desktop resolution width (1024px)
+@media screen and (max-device-width: 1023px) and (orientation: landscape){
+    .site-go-back-to-top {
+        display: none;
+    }
+}
+
+// Show if userAgent string matches ipad/iphone
+.js-is_iPad-iPhone .site-go-back-to-top {
+    display: flex;
+}
+
+// Show if iPad 1, 2, Mini and Air Landscape
+@media only screen
+and (min-device-width: 768px)
+and (max-device-width: 1024px)
+and (orientation: landscape)
+and (-webkit-min-device-pixel-ratio: 1) {
+    .site-go-back-to-top {
+        display: flex;
+    }
+}
+
+// Show if iPad 3, 4 and Pro 9.7 Landscape
+@media only screen
+and (min-device-width: 768px)
+and (max-device-width: 1024px)
+and (orientation: landscape)
+and (-webkit-min-device-pixel-ratio: 2) {
+    .site-go-back-to-top {
+        display: flex;
+    }
+}
+
+// Show if iPad Pro 10.5" Landscape
+@media only screen
+and (min-device-width: 1112px)
+and (max-device-width: 1112px)
+and (orientation: landscape)
+and (-webkit-min-device-pixel-ratio: 2) {
+    .site-go-back-to-top {
+        display: flex;
+    }
+}
+
+// Show if iPad Pro 12.9" Landscape
+@media only screen
+and (min-device-width: 1366px)
+and (max-device-width: 1366px)
+and (orientation: landscape)
+and (-webkit-min-device-pixel-ratio: 2) {
+    .site-go-back-to-top {
+        display: flex;
+    }
+}


### PR DESCRIPTION
Due to an gnarly issue where the back-to-top button is not clickable in Chrome on Android OS. 

Hide button all common mobile devices* :
- in portrait orientation up to known largest common device width [ max-device-width: 480px and orientation: portrait ] ". Most mobile phones have a device-width of 480px or lower" - ref http://javascriptkit.com/dhtmltutors/cssmediaqueries2.shtml
- in landscape orientation up to one px below smallest common desktop resolution 1024px : [max-device-width: 1023px and orientation: landscape] ref -https://mediag.com/blog/popular-screen-resolutions-designing-for-all/
- use CSS to show the button on ipads with device-specific media-queries with CSS.
- then progressively enhance to detect iPad/iPhone's with Javascript and apply a hook class to, again, show with CSS

* This does not capture tablets (or some larger phones in landscape mode) but tablets are a very small portion of site traffic and viewing the site on a phone in landscape is an unlikely behaviour.

    refs -
    Mobile IOS specific media queries - https://css-tricks.com/snippets/css/media-queries-for-standard-devices/
    ". Most mobile phones have a device-width of 480px or lower" - http://javascriptkit.com/dhtmltutors/cssmediaqueries2.shtml
    Common android viewport widths, and min laptop screen resolution -  https://mediag.com/blog/popular-screen-resolutions-designing-for-all/
    Desktop screen resolutions worldwide -  https://gs.statcounter.com/screen-resolution-stats/desktop/worldwide