### PR TITLE
Left align comments

### DIFF
--- a/src/6-information/comments/_index.scss
+++ b/src/6-information/comments/_index.scss
@@ -60,6 +60,7 @@
 .comment {
   background-color: color('iceberg');
   border-radius: border-radius('full');
+  border-top-left-radius: 0;
   margin-bottom: spacing('sm');
   padding: spacing('sm') spacing('md');
   font-size: rem(16);
@@ -81,15 +82,6 @@
 
   &.even {
       background-color: color('loafer');
-      border-top-right-radius: 0;
-      text-align: right;
-
-      .comment__info {
-          flex-direction: row-reverse;
-      }
   }
-
-  &.odd {
-      border-top-left-radius: 0;
-  }
+  
 }


### PR DESCRIPTION
As a Data.govt.nz user I want comments to be presented in a clear and familiar way so I can read them and contribute easily.

Comments that appear on blog posts or data requests currently display in a ‘conversational’ format that goes back and forth between colours and right and left alignment. This can make it look like people are replying to each other when they aren’t, or as if two comments from one user are from multiple people.

Comments should always be left-aligned. Colour variation could be retained for clarity.

A.C.:
All comments wherever they appear on the site are left-aligned

ref - Jira ticket: https://govtnz.atlassian.net/browse/DATA-597