### PR TITLE
slideDown/Up toggles display:block/none itself

### DIFF
--- a/src/9-plugins/toggler/options/slide.js
+++ b/src/9-plugins/toggler/options/slide.js
@@ -10,9 +10,6 @@
 
 import ariaexpanded from './ariaexpanded'
 
-const hiddenClass = 'hidden',
-  visibleClass = 'visible'
-
 export function init({
   element,
   state
@@ -28,13 +25,9 @@ export function run({
   state
 }) {
   if (state) {
-    $(element).slideDown(function () {
-      $(element).removeClass(hiddenClass).addClass(visibleClass)
-    })
+    $(element).slideDown()
   } else {
-    $(element).slideUp(function () {
-      $(element).addClass(hiddenClass).removeClass(visibleClass)
-    })
+    $(element).slideUp()
   }
   ariaexpanded.run({
     element,


### PR DESCRIPTION
adding classes that also do this can cause
side-effects, e.g. in CKAN 2.9.3 core the
'hidden' class is defined as:
.hidden { display:none !important }

jQuery slideDown toggles display to block before
animating, but the hidden class in slide.js
stayed on until the animation was complete.
This meant the slide element only became visible
once the animation was done (!important overrides
element styles)