### PR TITLE
SUPDATA-137 Remove box shadow on input focus and update search menu b…

### DIFF
--- a/src/3-general/form/_multi-choice.scss
+++ b/src/3-general/form/_multi-choice.scss
@@ -46,7 +46,7 @@ $mutlichoice-option-radius: border-radius('full') !default;
 $mutlichoice-option-font-size: rem(16);
 $mutlichoice-option-opacity-disabled: 0.25 !default;
 $mutlichoice-option-transition: $box-shadow-transition, background-color 0.25s ease-out, color 0.25s ease-out !default;
-$mutlichoice-option-shadow-hover: 0 3px 0 rgba(#000, .1) !default;
+$mutlichoice-option-shadow-hover: 0 0 0 2px color('white'), 0 0 0 4px $mutlichoice-background-hover !default;
 $mutlichoice-option-height: 40px !default;
 $mutlichoice-option-border-width: 2px !default;
 

--- a/src/3-general/form/_select.scss
+++ b/src/3-general/form/_select.scss
@@ -83,7 +83,6 @@ $select-arrow-position: calc(get-side($input-padding, 'right') / 2);
     outline: none;
     border: $input-border-focus;
     background-color: $input-background-focus;
-    box-shadow: $input-shadow-focus;
   }
 
   // Disabled state

--- a/src/3-general/form/_text.scss
+++ b/src/3-general/form/_text.scss
@@ -122,7 +122,6 @@
   border-radius: $input-radius;
   background-color: $input-background;
   transition: $input-transition;
-  box-shadow: $input-shadow;
 
   font-family: $input-font-family;
   font-size: $input-font-size;
@@ -135,7 +134,6 @@
     outline: none;
     border: $input-border-focus;
     background-color: $input-background-focus;
-    box-shadow: $input-shadow-focus;
   }
 }
 

--- a/src/7-layout/header/_index.scss
+++ b/src/7-layout/header/_index.scss
@@ -292,6 +292,10 @@ $menu-item-padding-left: get-side($site-header-menu-item-padding, "left");
 
 .search-toggle {
   position: relative;
+  display: flex;
+  flex-direction: row;
+  flex: 0 1 60px;    
+
   &__search {
     padding: em(10);
     color: color("primary");
@@ -309,6 +313,7 @@ $menu-item-padding-left: get-side($site-header-menu-item-padding, "left");
   }
 
   @include breakpoint(lg) {
+    flex: 0 1 120px;    
     &__desk-search {
       display: block;
     }

--- a/src/_globals.scss
+++ b/src/_globals.scss
@@ -165,6 +165,13 @@ $button-transition: $box-shadow-transition, background-color 0.25s ease-out, col
 $button-types: $colors !default;
 $button-shadow-hover: $box-shadow-hover !default;
 
+//=== Multichoice
+//
+
+$mutlichoice-background: color('primary') !default;
+$mutlichoice-background-hover: scale-color($mutlichoice-background, $lightness: -15%) !default;
+
+
 //== Forms
 //
 //##
@@ -187,7 +194,7 @@ $input-padding: 0.9em !default;
 $input-shadow: none !default;
 $input-shadow-focus: $box-shadow-hover !default;
 $input-cursor-disabled: not-allowed !default;
-$input-transition: $box-shadow-transition, box-shadow 0.5s, border-color 0.25s ease-in-out !default;
+$input-transition: border-color 0.25s ease-in-out !default;
 $input-radius: 1.5em !default;
 $form-button-radius: 1.5em !default;
 


### PR DESCRIPTION
SUPDATA-137
After reviewing the changes on Ckan we thought the input would be better without the box shadow on focus.
The input border changes to a slightly darker grey on focus and the presence of the blinking cursor should be enough to indicate it's in focus. https://www.w3.org/WAI/WCAG21/Understanding/non-text-contrast.html

I also updated the spacing of the search button in the header. It was previously shifting the menu items around when the button swapped between open and close version. 

Also update the multichoice focus styling to keep it consistent with no shadow for focus styling